### PR TITLE
解决微信小程序调试基础库3.4.10以上版本wx.getSystemInfoSync废弃的问题

### DIFF
--- a/components/Header/index.jsx
+++ b/components/Header/index.jsx
@@ -1,5 +1,5 @@
 import { useMemo, createContext, useContext as useReactContext, useEffect } from 'react'
-import { useDidShow, setNavigationBarTitle, getMenuButtonBoundingClientRect, setNavigationBarColor, getSystemInfoSync } from '@tarojs/taro'
+import { useDidShow, setNavigationBarTitle, getMenuButtonBoundingClientRect, setNavigationBarColor, getWindowInfo } from '@tarojs/taro'
 import { View, Image, Text } from '@tarojs/components'
 import { getContrastYIQ, route, pages as routePages, px } from '@/duxapp/utils'
 import theme from '@/duxapp/config/theme'
@@ -61,7 +61,7 @@ export const Header = ({
     // 小程序胶囊按钮宽度
     let jiaonangWidth = 0
     // 获取胶囊信息
-    const statusBarHeight = h5 ? 0 : (getSystemInfoSync().statusBarHeight || 0)
+    const statusBarHeight = h5 ? 0 : (getWindowInfo().statusBarHeight || 0)
     if (isPlatformMini) {
       const { width, height, top } = getMenuButtonBoundingClientRect() || {}
       if (width && top) {

--- a/components/Layout/index.rn.jsx
+++ b/components/Layout/index.rn.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, forwardRef } from 'react'
 import { View as NativeView } from 'react-native'
-import { getSystemInfoSync } from '@tarojs/taro'
+import { getWindowInfo } from '@tarojs/taro'
 import ClickableSimplified from '@tarojs/components-rn/dist/components/ClickableSimplified'
 
 const ClickView = ClickableSimplified(NativeView)
@@ -30,7 +30,7 @@ export const Layout = ({ children, onLayout, onClick, reloadKey, ...props }) => 
   useEffect(() => {
     if (viewRef.current && layoutStatus) {
       viewRef.current.measure((x, y, width, height, left, top) => {
-        const { windowWidth } = getSystemInfoSync()
+        const { windowWidth } = getWindowInfo()
         onLayoutRef.current?.({
           width: width || layoutData.current.width,
           height: height || layoutData.current.height,

--- a/components/List/index.jsx
+++ b/components/List/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, memo, useRef } from 'react'
 import { View, Text, Image } from '@tarojs/components'
-import { useDidShow, getSystemInfoSync } from '@tarojs/taro'
+import { useDidShow, getWindowInfo } from '@tarojs/taro'
 import { noop } from '@/duxapp/utils'
 import { ListLoading } from './Loading'
 import { ListSelect } from './Select'
@@ -173,7 +173,7 @@ export {
   ListLoading
 }
 
-const itemSize = px => px * getSystemInfoSync().screenWidth / 750
+const itemSize = px => px * getWindowInfo().screenWidth / 750
 
 const Empty = ({
   onEmptyClick,

--- a/components/RequestPermissionMessage/index.rn.jsx
+++ b/components/RequestPermissionMessage/index.rn.jsx
@@ -1,4 +1,4 @@
-import { getSystemInfoSync } from '@tarojs/taro'
+import { getWindowInfo } from '@tarojs/taro'
 import { Text, View } from '@tarojs/components'
 import { Platform, PermissionsAndroid } from 'react-native'
 import { asyncTimeOut, px, userConfig } from '@/duxapp/utils'
@@ -18,7 +18,7 @@ export const requestPermissionMessage = async (type, msg) => {
     }
     if (await check()) {
       const permissions = userConfig.option?.duxappReactNative?.permissions || {}
-      const { statusBarHeight = 0 } = getSystemInfoSync()
+      const { statusBarHeight = 0 } = getWindowInfo()
       const { remove } = TopView.add(<View
         className='absolute gap-1 p-3 r-2 z-1 bg-primary'
         style={{

--- a/components/ShowLoading/index.jsx
+++ b/components/ShowLoading/index.jsx
@@ -1,5 +1,5 @@
 import { View, Text } from '@tarojs/components'
-import { getSystemInfoSync } from '@tarojs/taro'
+import { getWindowInfo } from '@tarojs/taro'
 import { px, currentPage } from '@/duxapp/utils'
 import { TopView } from '../TopView'
 import { Loading } from '../Loading'
@@ -7,7 +7,7 @@ import { Loading } from '../Loading'
 import './index.scss'
 
 const getSize = size => {
-  const { windowWidth } = getSystemInfoSync()
+  const { windowWidth } = getWindowInfo()
   return 750 / windowWidth * size
 }
 
@@ -15,7 +15,7 @@ const ShowLoading = ({
   text = '请稍后',
   mask
 }) => {
-  const { windowWidth, windowHeight } = getSystemInfoSync()
+  const { windowWidth, windowHeight } = getWindowInfo()
 
   return <>
     {mask && <View className='ShowLoading__mask' />}

--- a/utils/util.js
+++ b/utils/util.js
@@ -1,4 +1,4 @@
-import { pxTransform, getSystemInfoSync, showToast } from '@tarojs/taro'
+import { pxTransform, getWindowInfo, showToast } from '@tarojs/taro'
 import { Platform } from '@/duxapp/utils/rn/util'
 
 export const toast = msg => {
@@ -12,14 +12,14 @@ export const toast = msg => {
   })
 }
 
-let systemInfo
+let winInfo
 export const isIphoneX = () => {
-  systemInfo = systemInfo || getSystemInfoSync()
+  winInfo = winInfo || getWindowInfo()
   if (process.env.TARO_ENV === 'rn') {
-    Platform.OS !== 'android' && systemInfo.safeArea?.bottom < systemInfo.screenHeight
+    Platform.OS !== 'android' && winInfo.safeArea?.bottom < winInfo.screenHeight
   } else {
     const phoneMarks = ['iPhone X', 'iPhone 11', 'iPhone 12', 'iPhone 13', 'iPhone 14', 'iPhone 15', 'iPhone 16', 'iPhone 17']
-    const { model = '' } = systemInfo
+    const { model = '' } = winInfo
     for (let i = 0, l = phoneMarks.length; i < l; i++) {
       if ((model || '').startsWith(phoneMarks[i])) return true
     }
@@ -82,7 +82,7 @@ export const pxNum = (() => {
   let windowWidth
   return val => {
     if (!windowWidth) {
-      windowWidth = getSystemInfoSync().windowWidth
+      windowWidth = getWindowInfo().windowWidth
     }
     return val / 750 * windowWidth
   }


### PR DESCRIPTION
消除调试输出的警告：wx.getSystemInfoSync is deprecated.Please use wx.getSystemSetting/wx.getAppAuthorizeSetting/wx.getDeviceInfo/wx.getWindowInfo/wx.getAppBaseInfo instead.