### PR TITLE
fix: 单词错误

### DIFF
--- a/components/ScrollView/index.jsx
+++ b/components/ScrollView/index.jsx
@@ -24,7 +24,7 @@ export const ScrollView = ({
       scrollWithAnimation={scrollWithAnimation}
       refresherEnabled={refresh !== undefined}
       refresherThreshold={50}
-      onRefresherrefresh={() => {
+      onRefresherRefresh={() => {
         !refresh && onRefresh?.()
       }}
       refresherTriggered={!!refresh}


### PR DESCRIPTION
<img width="882" height="452" alt="image" src="https://github.com/user-attachments/assets/c6054f0d-c0cf-41d9-8008-f2e4ce409825" />
在taro scrollview中正确的props为：onRefresherRefresh。单词错误

